### PR TITLE
Add test for `gdc_check_new`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ setup(
     scripts=scripts,
     entry_points={
         'console_scripts': [
-            'xge = xena_gdc_etl.main:main'
+            'xge = xena_gdc_etl.main:main',
+            'gdc2xena = xena_gdc_etl.gdc2xena:main',
         ],
     },
     license='Apache License 2.0',

--- a/tests/fixtures/gdc_check_new_DR9.0_files_swap.csv
+++ b/tests/fixtures/gdc_check_new_DR9.0_files_swap.csv
@@ -1,0 +1,6 @@
+analysis.workflow_type  cases   cases.project.project_id        data_type
+HTSeq - Counts          TARGET-NBL      Gene Expression Quantification
+HTSeq - FPKM-UQ         TARGET-NBL      Gene Expression Quantification
+HTSeq - Counts          TARGET-NBL      Gene Expression Quantification
+HTSeq - FPKM            TARGET-NBL      Gene Expression Quantification
+HTSeq - FPKM-UQ         TARGET-NBL      Gene Expression Quantification

--- a/tests/test_gdc2xena.py
+++ b/tests/test_gdc2xena.py
@@ -1,0 +1,55 @@
+import unittest
+
+from xena_gdc_etl import gdc2xena
+
+
+class ParserTest(unittest.TestCase):
+    def setUp(self):
+        self.parser = gdc2xena.create_parser()
+
+    def test_etl(self):
+        parsed = self.parser.parse_args([
+            "etl",
+            "-r", 
+            "path/to/dir",
+            "-p",
+            "project_name",
+            "-t",
+            "datatype",
+        ])
+        assert parsed.subcomm == "etl"
+        assert parsed.root == "path/to/dir"
+        assert parsed.projects == ["project_name"]
+        assert parsed.datatype == ["datatype"]
+        # for mutually exclusive groups
+        parsed = self.parser.parse_args([
+            "etl",
+            "-r", 
+            "path/to/dir",
+            "-P",
+            "not_this_project_name",
+            "-T",
+            "not_this_datatype",
+        ])
+        assert parsed.subcomm == "etl"
+        assert parsed.root == "path/to/dir"
+        assert parsed.not_projects == ["not_this_project_name"]
+        assert parsed.not_datatype == ["not_this_datatype"]
+
+    def test_metaparser(self):
+        parsed = self.parser.parse_args([
+            "metadata",
+            "-p",
+            "project_name",
+            "-t",
+            "datatype",
+            "-m",
+            "path/to/matrix",
+            "-r",
+            "10",
+        ])
+        assert parsed.subcomm == "metadata"
+        assert parsed.project == "project_name"
+        assert parsed.datatype == "datatype"
+        assert parsed.matrix == "path/to/matrix"
+        assert parsed.release == 10.0

--- a/tests/test_gdc_check_new.py
+++ b/tests/test_gdc_check_new.py
@@ -5,18 +5,16 @@ except ImportError:
 
 import pandas as pd
 import pytest
-from mock import patch
 
 from xena_gdc_etl import gdc_check_new
 
 
 @pytest.mark.CI
-@patch("sys.stdout", new_callable=StringIO)
-def test_gdc_check_new(mocked_stdout):
+def test_gdc_check_new(capfd):
     url = "https://docs.gdc.cancer.gov/Data/Release_Notes/DR9.0_files_swap.txt.gz"  # noqa
     gdc_check_new.gdc_check_new(url)
-    actual = StringIO(mocked_stdout.getvalue())
-    actual = pd.read_csv(actual, sep='\t')
+    out, err = capfd.readouterr()
+    actual = pd.read_csv(StringIO(out), sep='\t')
     expected = pd.read_csv("tests/fixtures/gdc_check_new_DR9.0_files_swap.csv",
                            sep='\t')
     expected = expected.head()

--- a/tests/test_gdc_check_new.py
+++ b/tests/test_gdc_check_new.py
@@ -1,0 +1,23 @@
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
+import pandas as pd
+import pytest
+from mock import patch
+
+from xena_gdc_etl import gdc_check_new
+
+
+@pytest.mark.CI
+@patch("sys.stdout", new_callable=StringIO)
+def test_gdc_check_new(mocked_stdout):
+    url = "https://docs.gdc.cancer.gov/Data/Release_Notes/DR9.0_files_swap.txt.gz"  # noqa
+    gdc_check_new.gdc_check_new(url)
+    actual = StringIO(mocked_stdout.getvalue())
+    actual = pd.read_csv(actual, sep='\t')
+    expected = pd.read_csv("tests/fixtures/gdc_check_new_DR9.0_files_swap.csv",
+                           sep='\t')
+    expected = expected.head()
+    actual.equals(expected)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -19,7 +19,7 @@ class ParserTest(unittest.TestCase):
         assert parsed.datatype == "datatype"
 
     def test_gdc_check_new(self):
-        parsed = self.parser.parse_args(["gdc_check_new",
+        parsed = self.parser.parse_args(["gdc-check-new",
                                         "https://example.com/data.gz"])
         assert parsed.url == "https://example.com/data.gz"
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,9 +8,10 @@ except ImportError:
     from io import StringIO
 
 import pandas as pd
-import pytest
 
 from xena_gdc_etl import utils
+
+PATH = "tests/fixtures/"  # path to static files
 
 
 def test_mkdir_p():
@@ -21,42 +22,38 @@ def test_mkdir_p():
     os.rmdir(input_)
 
 
-@pytest.fixture
 @patch("sys.stdout", new_callable=StringIO)
 def test_equal_matrices(mocked_print):
-    utils.equal_matrices("df1.csv", "df2.csv")
-    utils.equal_matrices("df1.csv", "df3.csv")
+    utils.equal_matrices(PATH + "df1.csv", PATH + "df2.csv")
+    utils.equal_matrices(PATH + "df1.csv", PATH + "df3.csv")
     assert mocked_print.getvalue() == "Not equal.\nEqual.\n"
 
 
-@pytest.fixture
 @patch.object(utils, 'time', Mock(wraps=time))
 def test_metadata():
     utils.time.gmtime.return_value = time.struct_time(
         (2019, 4, 28, 0, 0, 0, 0, 0, 0)
     )
-    path_to_df = "HTSeq-FPKM-UQ.csv"
+    path_to_df = PATH + "HTSeq-FPKM-UQ.csv"
     utils.metadata(path_to_df, "htseq_fpkm-uq")
-    with open("HTSeq-FPKM-UQ.csv.json", "r") as actual:
+    with open(PATH + "HTSeq-FPKM-UQ.csv.json", "r") as actual:
         actual = json.load(actual)
-    os.unlink("HTSeq-FPKM-UQ.csv.json")
-    with open("HTSeq-FPKM-UQ.json", "r") as expected:
+    os.unlink(PATH + "HTSeq-FPKM-UQ.csv.json")
+    with open(PATH + "HTSeq-FPKM-UQ.json", "r") as expected:
         expected = json.load(expected)
     assert actual == expected
 
 
-@pytest.fixture
 def test_merge_xena():
     name = "merged_GDC_TARGET-CCSK.tsv"
     filelists = ["merge-xena1.csv", "merge-xena2.csv"]
     cohort = "GDC TARGET-CCSK"
     datatype = "GDC_phenotype"
-    path = "tests/fixtures"
-    outdir = path
+    outdir = PATH
     utils.handle_merge_xena(name, filelists, cohort, datatype, outdir)
-    with open("MergedCohort04292019.GDC_phenotype.tsv", "r") as actual:
+    with open(PATH + "MergedCohort04292019.GDC_phenotype.tsv", "r") as actual:
         actual = pd.read_csv(actual)
-    with open(path + name, "r") as expected:
+    with open(PATH + name, "r") as expected:
         expected = pd.read_csv(expected)
-    os.unlink(path + name)
+    os.unlink(PATH + name)
     actual.equals(expected)

--- a/xena_gdc_etl/gdc_check_new.py
+++ b/xena_gdc_etl/gdc_check_new.py
@@ -11,7 +11,7 @@ def gdc_check_new(url):
     updated files and summarize impacted project(s), data_type(s) and
     analysis.workflow_type(s).
     """
-    new_uuids = pd.read_table(url)['New File UUID'].tolist()
+    new_uuids = pd.read_csv(url, sep='\t')['New File UUID'].tolist()
     df_list = []
     for uuids in (new_uuids[i:i + 20000]
                   for i in range(0, len(new_uuids), 20000)):

--- a/xena_gdc_etl/main.py
+++ b/xena_gdc_etl/main.py
@@ -12,20 +12,20 @@ def main():
     Program entry point
     """
     parser = create_parser()
-    options = vars(parser.parse_args())
+    options = parser.parse_args()
     # handle check xena equality matrices
-    if 'df1' in options and 'df2' in options:
-        equal_matrices(options['df1'], options['df2'])
+    if options.subcomm == "xena-eql":
+        equal_matrices(options.df1, options.df2)
     # handle make metadata
-    elif "matrix" in options and "datatype" in options:
-        metadata(options["matrix"], options["datatype"])
+    elif options.subcomm == "make-metadata":
+        metadata(options.matrix, options.datatype)
     # handle gdc_check_new
-    elif "url" in options:
-        gdc_check_new(options["url"])
+    elif options.subcomm == "gdc-check-new":
+        gdc_check_new(options.url)
     # handle merge_xena
-    elif "files" in options and "datatype" in options:
-        handle_merge_xena(options["name"], options["files"], options["cohort"],
-                          options["datatype"], options["outdir"])
+    elif options.subcomm == "merge-xena":
+        handle_merge_xena(options.name, options.files, options.cohort,
+                          options.datatype, options.outdir)
 
 
 def create_parser():

--- a/xena_gdc_etl/main.py
+++ b/xena_gdc_etl/main.py
@@ -68,7 +68,7 @@ def create_parser():
     )
     # gdc_check_new subparser
     gdc_check_new_parser = subparsers.add_parser(
-        "gdc_check_new",
+        "gdc-check-new",
         description="Check GDC's list of updated files and summarize "
                     "impacted project(s), data_type(s) and "
                     "analysis.workflow_type(s)."

--- a/xena_gdc_etl/xena_dataset.py
+++ b/xena_gdc_etl/xena_dataset.py
@@ -28,9 +28,9 @@ import numpy as np
 import pandas as pd
 import requests
 
-import gdc
-from xena_gdc_etl.utils import mkdir_p
-from constants import METADATA_TEMPLATE, METADATA_VARIABLES
+from xena_gdc_etl import gdc
+from .utils import mkdir_p
+from .constants import METADATA_TEMPLATE, METADATA_VARIABLES
 
 
 # Map GDC project_id to Xena specific cohort name.
@@ -1002,7 +1002,7 @@ class GDCOmicset(XenaDataset):
                               jinja2.environment.Template)
             return self.__metadata_template
         except (AttributeError, AssertionError):
-            template_json = self.METADATA_TEMPLATE[self.xena_dtype]
+            template_json = METADATA_TEMPLATE[self.xena_dtype]
             jinja2_env = jinja2.Environment(
                     loader=jinja2.PackageLoader('xena_gdc_etl', 'resources')
                 )
@@ -1028,7 +1028,7 @@ class GDCOmicset(XenaDataset):
             else:
                 variables['xena_cohort'] = 'GDC ' + projects
             try:
-                variables.update(self.METADATA_VARIABLES[self.xena_dtype])
+                variables.update(METADATA_VARIABLES[self.xena_dtype])
             except KeyError:
                 pass
             # Data type specific jinja2 Variables


### PR DESCRIPTION
- My previous implementation of `pytest.fixture` was wrong. In my implementation, I was wrongly creating fixtures not using them in the tests. 8c70670 removes the error.
- Also added the missing test for `gdc-check-new` which was not implemented in #23 in 5a5aa5a.

I will send a PR updating the docs once the CLI for `gdc2xena` is ready.