### PR TITLE
Log a unfinished.json file

### DIFF
--- a/tests/fixtures/unfinished_test.json
+++ b/tests/fixtures/unfinished_test.json
@@ -1,0 +1,4 @@
+{
+    "SOME_PROJECT1": ["htseq_counts", "methylation450"],
+    "SOME_PROJECT2": ["htseq_counts", "methylation450"]
+}

--- a/tests/test_gdc2xena.py
+++ b/tests/test_gdc2xena.py
@@ -8,6 +8,7 @@ from xena_gdc_etl import gdc2xena
 
 PATH = "tests/fixtures/"
 
+
 @pytest.mark.CI
 def test_logging():
     gdc2xena.gdc2xena(

--- a/tests/test_gdc2xena.py
+++ b/tests/test_gdc2xena.py
@@ -10,7 +10,7 @@ PATH = "tests/fixtures/"
 
 
 @pytest.mark.CI
-def test_logging():
+def test_unfinished_generation():
     gdc2xena.gdc2xena(
         root_dir=".",
         projects=["SOME_PROJECT1", "SOME_PROJECT2"],

--- a/tests/test_gdc2xena.py
+++ b/tests/test_gdc2xena.py
@@ -1,0 +1,23 @@
+import json
+import os
+
+import pytest
+
+from xena_gdc_etl import gdc2xena
+
+
+PATH = "tests/fixtures/"
+
+@pytest.mark.CI
+def test_logging():
+    gdc2xena.gdc2xena(
+        root_dir=".",
+        projects=["SOME_PROJECT1", "SOME_PROJECT2"],
+        xena_dtypes=["htseq_counts", "methylation450"],
+    )
+    with open(PATH + "unfinished_test.json", "r") as infile:
+        expected = json.load(infile)
+    with open("unfinished.json", "r") as infile:
+        actual = json.load(infile)
+    assert actual == expected
+    os.unlink("unfinished.json")

--- a/xena_gdc_etl/gdc2xena.py
+++ b/xena_gdc_etl/gdc2xena.py
@@ -25,6 +25,7 @@ from __future__ import print_function
 import os
 import logging
 import timeit
+import json
 
 from .xena_dataset import GDCOmicset, GDCPhenoset, GDCSurvivalset
 
@@ -55,6 +56,7 @@ def gdc2xena(root_dir, projects, xena_dtypes):
     """
     start_time = timeit.default_timer()
     counts = 0
+    unfinished = {}
     total_projects = len(projects)
     log_format = '%(asctime)-15s [%(levelname)s]: %(message)s'
     logging.basicConfig(
@@ -84,9 +86,15 @@ def gdc2xena(root_dir, projects, xena_dtypes):
             try:
                 dataset.download().transform().metadata()
             except Exception:
+                if project not in unfinished:
+                    unfinished[project] = [dtype]
+                else:
+                    unfinished[project].append(dtype)
                 msg = 'No {} data for cohort {}.'.format(dtype, project)
                 logger.warning(msg, exc_info=True)
                 print(msg)
+    with open("unfinished.json", "w") as outfile:
+        json.dump(unfinished, outfile)
     logging.shutdown()
     end_time = timeit.default_timer()
     m, s = divmod(int(end_time - start_time), 60)

--- a/xena_gdc_etl/gdc2xena.py
+++ b/xena_gdc_etl/gdc2xena.py
@@ -90,11 +90,11 @@ def gdc2xena(root_dir, projects, xena_dtypes):
                     unfinished[project] = [dtype]
                 else:
                     unfinished[project].append(dtype)
+                with open("unfinished.json", "w") as outfile:
+                    json.dump(unfinished, outfile)
                 msg = 'No {} data for cohort {}.'.format(dtype, project)
                 logger.warning(msg, exc_info=True)
                 print(msg)
-    with open("unfinished.json", "w") as outfile:
-        json.dump(unfinished, outfile)
     logging.shutdown()
     end_time = timeit.default_timer()
     m, s = divmod(int(end_time - start_time), 60)

--- a/xena_gdc_etl/gdc2xena.py
+++ b/xena_gdc_etl/gdc2xena.py
@@ -90,7 +90,10 @@ def gdc2xena(root_dir, projects, xena_dtypes):
                     unfinished[project] = [dtype]
                 else:
                     unfinished[project].append(dtype)
-                with open("unfinished.json", "w") as outfile:
+                with open(
+                    os.path.join(root_dir, "unfinished.json"),
+                    "w",
+                ) as outfile:
                     json.dump(unfinished, outfile)
                 msg = 'No {} data for cohort {}.'.format(dtype, project)
                 logger.warning(msg, exc_info=True)


### PR DESCRIPTION
This will keep the dataypes and their corresponding
projects for which the ETL was not finished.