### PR TITLE
Add a CLI option to delete raw data upon generation of xena_matrix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,7 @@ Basic usage with command line tools
     xge etl [-h] [-r ROOT]
             [-p PROJECTS [PROJECTS ...] | -P NOT_PROJECTS [NOT_PROJECTS ...]]
             [-t DATATYPE [DATATYPE ...] | -T NOT_DATATYPE [NOT_DATATYPE ...]]
+            [-D DELETE]
 
   This tool will perform a full import of dataset(s) into the root directory (specified by the ``-r`` option) with a default directory tree. In general, a full import has 3 steps: downloading raw data, making Xena matrix from raw data and generating matrix associated metadata. Data from each step will be saved to corresponding directories, whose structure is like this:
 

--- a/tests/test_gdc2xena.py
+++ b/tests/test_gdc2xena.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shutil
 
 import pytest
 
@@ -22,3 +23,21 @@ def test_unfinished_generation():
         actual = json.load(infile)
     assert actual == expected
     os.unlink("unfinished.json")
+
+
+@pytest.mark.CI
+def test_deletion_of_raw_data():
+    os.mkdir("test_deletion")
+    gdc2xena.gdc2xena(
+        root_dir="test_deletion",
+        projects=["TCGA-ACC"],
+        xena_dtypes=["muse_snv"],
+        delete_raw_data=True,
+    )
+    path = "/test_deletion/TCGA-ACC/Raw-Data/"
+    all_files = []
+    for root, _, files in os.walk(path):
+        for file in files:
+            all_files.append(os.path.join(root, file))
+    assert all_files == []
+    shutil.rmtree("test_deletion")

--- a/tests/test_gdc2xena.py
+++ b/tests/test_gdc2xena.py
@@ -30,11 +30,11 @@ def test_deletion_of_raw_data():
     os.mkdir("test_deletion")
     gdc2xena.gdc2xena(
         root_dir="test_deletion",
-        projects=["TCGA-ACC"],
-        xena_dtypes=["muse_snv"],
+        projects=["TCGA-UVM"],
+        xena_dtypes=["somaticsniper_snv"],
         delete_raw_data=True,
     )
-    path = "/test_deletion/TCGA-ACC/Raw-Data/"
+    path = "/test_deletion/TCGA-UVM/Raw-Data/"
     all_files = []
     for root, _, files in os.walk(path):
         for file in files:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -61,12 +61,14 @@ class ParserTest(unittest.TestCase):
                 "project_name",
                 "-t",
                 "datatype",
+                "-D",
             ]
         )
         assert parsed.subcomm == "etl"
         assert parsed.root == "path/to/dir"
         assert parsed.projects == ["project_name"]
         assert parsed.datatype == ["datatype"]
+        assert parsed.delete is True
         # for mutually exclusive groups
         parsed = self.parser.parse_args(
             [

--- a/xena_gdc_etl/gdc2xena.py
+++ b/xena_gdc_etl/gdc2xena.py
@@ -27,11 +27,12 @@ import logging
 import timeit
 import json
 import time
+import shutil
 
 from .xena_dataset import GDCOmicset, GDCPhenoset, GDCSurvivalset
 
 
-def gdc2xena(root_dir, projects, xena_dtypes):
+def gdc2xena(root_dir, projects, xena_dtypes, delete_raw_data=False):
     """Start a pipeline for importing data from GDC to Xena.
 
     Data will be imported on a dataset basis, which is defined by project
@@ -54,6 +55,8 @@ def gdc2xena(root_dir, projects, xena_dtypes):
             "htseq_fpkm-uq", "mirna", "masked_cnv", "muse_snv", "mutect2_snv",
             "somaticsniper_snv", "varscan2_snv", "phenotype", "survival",
             "methylation27", "methylation450".
+        delete_raw_data (optional, bool): Delete raw data upon generation
+            of xena_matrix.
     """
     start_time = timeit.default_timer()
     counts = 0
@@ -88,6 +91,9 @@ def gdc2xena(root_dir, projects, xena_dtypes):
                 dataset = GDCOmicset(project, dtype, root_dir)
             try:
                 dataset.download().transform().metadata()
+                if delete_raw_data:
+                    print("Deleting raw data ...")
+                    shutil.rmtree(dataset.raw_data_dir)
             except Exception:
                 if project not in unfinished:
                     unfinished[project] = [dtype]

--- a/xena_gdc_etl/main.py
+++ b/xena_gdc_etl/main.py
@@ -58,6 +58,7 @@ def main():
         )
     # handle etl
     elif options.subcomm == 'etl':
+        delete_raw_data = options.delete
         root_dir = os.path.abspath(options.root)
         projects = options.projects
         if 'all' in [p.lower() for p in projects]:
@@ -77,7 +78,7 @@ def main():
         print(str(xena_dtypes), end='\n\n')
         print('into this directory: {}'.format(root_dir))
         print('########################################', end='\n\n')
-        gdc2xena(root_dir, projects, xena_dtypes)
+        gdc2xena(root_dir, projects, xena_dtypes, delete_raw_data)
     # handle metadata
     elif options.subcomm == 'metadata':
         root_dir = os.path.dirname(options.matrix)
@@ -212,6 +213,12 @@ def create_parser():
         type=str,
         default='.',
         help='Root directory for imported data.',
+    )
+    etlparser.add_argument(
+        '-D',
+        '--delete',
+        action='store_true',
+        help='Deletes raw data upon generation of Xena_matrix.',
     )
     projects_group = etlparser.add_mutually_exclusive_group()
     projects_group.add_argument(


### PR DESCRIPTION
I am using this in the AWS. Basically, it deletes the raw data corresponding to a data type once the xena matrix is generated. Let me know if we need it, I will add tests and update the docs.